### PR TITLE
make compatible with python 3

### DIFF
--- a/snaptime/main.py
+++ b/snaptime/main.py
@@ -1,6 +1,7 @@
 
 
 import re
+from functools import reduce
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 import pytz
@@ -41,7 +42,7 @@ UNIT_LISTS = {
 
 def get_unit(string):
 
-    for unit, variants in UNIT_LISTS.iteritems():
+    for unit, variants in UNIT_LISTS.items():
         if string in variants:
             return unit
 


### PR DESCRIPTION
Hi,

Thanks for this very useful package.

I am quite new to working on a properly organized Python project, so I hope you can bear with me here.

I tried to run the tests with py.test (something I have never done before) and it came back with 7 failed and and 81 passed - the error message being "AttributeError: 'SnapParseError' object has no attribute 'message'". This was before I made any changes. Same results with Python 2 and 3.

Is this intended?

Anyway, here is a proposal for making the module work with Python 3.

If you don't like the items() performance loss, there's some other suggestions on http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items

