### PR TITLE
Setuptools now requires configuration keys to use underscores instead of dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 ### snaptime
 
+.. note::
+    This is a fork of `snaptime <https://github.com/zartstrom/snaptime>`_ to workaround an `issue with setuptools <https://github.com/zartstrom/snaptime/pull/6>`_.
+
+
 The snaptime package is about transforming timestamps simply.
 
 It is inspired by splunks relative time modifiers, see their docs [here][splunk-docs].

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from distutils.core import setup
 
 
 setup(
-    name='snaptime',
+    name='nucypher-snaptime',
     packages=['snaptime'],  # this must be the same as the name above
-    version='0.2.4',
+    version='0.2.5',
     description='Transform timestamps with a simple DSL',  # think of including iconic '+1d@d' or similar
     install_requires=['python-dateutil', 'pytz'],
     author='Philipp Hitzler',


### PR DESCRIPTION
(Thanks to @elapfra)
Fixes #7 